### PR TITLE
Bug#8356: Uninstall process of Latch plugin fails in ownCloud 8

### DIFF
--- a/latch_plugin/appinfo/routes.php
+++ b/latch_plugin/appinfo/routes.php
@@ -19,4 +19,7 @@
   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-$this->create('latch_uninstall','uninstall.php')->actionInclude('latch_plugin/uninstall.php');
+$this->create('latch_uninstall','uninstall.php')
+        ->actionInclude('latch_plugin/uninstall.php');
+$this->create('latch_uninstallrenderer', 'uninstallRenderer.php')
+        ->actionInclude('latch_plugin/uninstallRenderer.php');

--- a/latch_plugin/js/uninstallPopup.js
+++ b/latch_plugin/js/uninstallPopup.js
@@ -24,7 +24,7 @@ function showuninstallwarning(){
 		speed:100, 
 		width:"70%", 
 		height:"70%", 
-		href: OC.filePath('latch_plugin', '', 'uninstallRenderer.php'),
+		href: OC.linkTo('latch_plugin', 'uninstallRenderer.php'),
 		onComplete : function(){
 			if (!SVGSupport()) {
 				replaceSVG();


### PR DESCRIPTION
Added new entry to file 'appinfo/routes.php'. The pop-up window that appears when the plugin is going to be disabled is now properly displayed.